### PR TITLE
Add support for responsive images

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The constructor accepts three arguments and returns a new instance of the cloudi
 | loader     | Object    | The loader is a parameter provided by the ckeditor which contains things like the `file`, `total upload size`, `uploaded`. | N/A |
 | cloudName  | string | This is the cloud name gotten from your cloudinary dashboard | 'MyCloud' |
 | unsignedUploadPreset | string | This is the upload preset you created on cloudinary using [these steps](https://support.cloudinary.com/hc/en-us/articles/360004967272-Upload-Preset-Configuration) | 'MyPreset' |
+| sizes _optional_    | number[] | This is an array of numbers that holds the sizes in px of images you wish to have in the editor. It helps ckeditor with responsive images. | [ 160, 500, 1000 ] |
 
 ### Methods
 
@@ -66,4 +67,3 @@ This package is open to contributions from the community. If you find it useful 
 ## Intended Features
 
 - Support for signedUploadPresets
-- Support for image sizes

--- a/src/CloudinaryImageUploadAdapter/CloudinaryImageUploadAdapter.ts
+++ b/src/CloudinaryImageUploadAdapter/CloudinaryImageUploadAdapter.ts
@@ -1,58 +1,109 @@
+import { IImageObject } from '../models/IImageObject';
+import { ISplitUrl } from '../models/ISplitUrl';
+
 export class CloudinaryImageUploadAdapter {
   public loader: any;
   private xhr: XMLHttpRequest;
   private cloudName: string;
   private unsignedUploadPreset: string;
+  private sizes?: number[];
 
-  constructor(loader: any, cloudName: string, unsignedUploadPreset: string) {
+  constructor(loader: any, cloudName: string, unsignedUploadPreset: string, sizes?: number[]) {
     this.loader = loader;
     this.xhr = new XMLHttpRequest();
     this.cloudName = cloudName;
     this.unsignedUploadPreset = unsignedUploadPreset;
+    if (sizes) {
+      this.sizes = sizes;
+    }
   }
 
   public upload() {
-    return this.loader.file
-      .then( (file: File) => new Promise((resolve, reject) => {
-        const fd = new FormData();
-        const url = `https://api.cloudinary.com/v1_1/${this.cloudName}/upload`;
-        this.xhr.open('POST', url, true);
-        this.xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+    return this.loader.file.then(
+      (file: File) =>
+        new Promise((resolve, reject) => {
+          const fd = new FormData();
+          const url = `https://api.cloudinary.com/v1_1/${this.cloudName}/upload`;
+          this.xhr.open('POST', url, true);
+          this.xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 
-        // Hookup an event listener to update the upload progress bar
-        this.xhr.upload.addEventListener('progress', e => {
-          this.loader.uploadTotal = 100;
-          this.loader.uploaded = Math.round((e.loaded * 100) / e.total);
-        });
+          // Hookup an event listener to update the upload progress bar
+          this.xhr.upload.addEventListener('progress', e => {
+            this.loader.uploadTotal = 100;
+            this.loader.uploaded = Math.round((e.loaded * 100) / e.total);
+          });
 
-        // Hookup a listener to listen for when the request state changes
-        this.xhr.onreadystatechange = () => {
-          if (this.xhr.readyState === 4 && this.xhr.status === 200) {
-            // Successful upload, resolve the promise with the new image
-            const response = JSON.parse(this.xhr.responseText);
-            const cloudImageUrl = response.secure_url;
+          // Hookup a listener to listen for when the request state changes
+          this.xhr.onreadystatechange = () => {
+            if (this.xhr.readyState === 4 && this.xhr.status === 200) {
+              // Successful upload, resolve the promise with the new image
+              const response = JSON.parse(this.xhr.responseText);
 
-            resolve({
-              default: cloudImageUrl
-            });
-          } else if (this.xhr.status !== 200) {
-            // Unsuccessful request, reject the promise
-            reject('Upload failed');
-          }
-        };
+              let images;
 
-        // Setup the form data to be sent in the request
-        fd.append('upload_preset', this.unsignedUploadPreset);
-        fd.append('tags', 'browser_upload');
-        fd.append('file', file);
-        this.xhr.send(fd);
-      }));
+              if (this.sizes) {
+                images = {
+                  default: response.secure_url,
+                  ...this.getImageSizes(response.secure_url),
+                };
+              } else {
+                images = {
+                  default: response.secure_url,
+                };
+              }
+
+              resolve(images);
+            } else if (this.xhr.status !== 200) {
+              // Unsuccessful request, reject the promise
+              reject('Upload failed');
+            }
+          };
+
+          // Setup the form data to be sent in the request
+          fd.append('upload_preset', this.unsignedUploadPreset);
+          fd.append('tags', 'browser_upload');
+          fd.append('file', file);
+          this.xhr.send(fd);
+        }),
+    );
   }
 
   public abort() {
     // This function is called to abort the request if an error occurs
-    if ( this.xhr ) {
+    if (this.xhr) {
       this.xhr.abort();
     }
+  }
+
+  private getImageSizes(defaultImageUrl: string): IImageObject {
+    const imageObject: IImageObject = {};
+
+    // Split url in two
+    const splitUrl = this.splitUrl(defaultImageUrl);
+
+    if (this.sizes) {
+      const len = this.sizes.length;
+      this.sizes.forEach((size: number, index: number) => {
+        if (index !== len - 1) {
+          imageObject[size.toString()] = `${splitUrl.firstHalf}w_${size},c_scale${splitUrl.secondHalf}`;
+        } else {
+          imageObject[size.toString()] = defaultImageUrl;
+        }
+      });
+    }
+
+    return imageObject;
+  }
+
+  private splitUrl(url: string): ISplitUrl {
+    // This function splits the image url in two.
+    const firstHalfLength = 41 + this.cloudName.length;
+    const firstHalf = url.substr(0, firstHalfLength);
+    const secondHalf = url.substr(firstHalfLength - 1, url.length - firstHalfLength + 1);
+
+    return {
+      firstHalf,
+      secondHalf,
+    };
   }
 }

--- a/src/models/IImageObject.ts
+++ b/src/models/IImageObject.ts
@@ -1,0 +1,3 @@
+export interface IImageObject {
+  [key: string]: any;
+}

--- a/src/models/ISplitUrl.ts
+++ b/src/models/ISplitUrl.ts
@@ -1,0 +1,4 @@
+export interface ISplitUrl {
+  firstHalf: string;
+  secondHalf: string;
+}


### PR DESCRIPTION
# Add Support For Responsive Images

## What does this PR do
This pull request adds the ability to uses responsive images in the editor.

## Background context
The ckeditor manages responsive images on its own. When the right sizes are provided. With this new feature, the image upload adapter would try to generate the various image sizes requested by the user.

## Task completed (detailed list of changes/additions)
- [x] Updated the README
- [x] Added two private methods and a sizes property
- [x] Added the functionality to build the image sizes links for cloudinary
